### PR TITLE
Feature/strict boolean expressions to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
     extends: 'standard-with-typescript',
     rules: {
+        '@typescript-eslint/strict-boolean-expressions': 0,
         '@typescript-eslint/naming-convention': [
             'error',
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gymboxx-typescript",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "ESlint rules for gymboxx system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* strict boolean expressions 룰을 해지할까 합니다. 디비에서 Null 값이 오는 경우 undefined로 체크가 안되다보니 코드가 불필요하게 길어지는거 같습니다.
ex) if (someValue !== undefined || somevalue !== null) -> if (!someValue)